### PR TITLE
Fixing an Issue with .dtag Files with No Redirectors

### DIFF
--- a/addons/dtag.daylily-zeleen/editor/diff.txt
+++ b/addons/dtag.daylily-zeleen/editor/diff.txt
@@ -1,0 +1,72 @@
+diff --git a/parser.gd b/../../../../../ProjectAlliance/Engine/addons/dtag.daylily-zeleen/editor/parser.gd
+index 38b8115..88dc9cf 100644
+--- a/parser.gd
++++ b/../../../../../ProjectAlliance/Engine/addons/dtag.daylily-zeleen/editor/parser.gd
+@@ -37,6 +37,7 @@ static func parse(text: String, r_err_info: Dictionary[int, String] = {}) -> Dic
+ 		if identifiler.begins_with("@"):
+ 			var domain := DomainDef.new()
+ 			domain.name = identifiler.trim_prefix("@").strip_edges()
++			print(domain.name)
+ 			domain.redirect = redirect
+ 			domain.desc = comment
+ 			if indent_count == curr_indent:
+@@ -48,8 +49,8 @@ static func parse(text: String, r_err_info: Dictionary[int, String] = {}) -> Dic
+ 						ret[domain.name] = domain
+ 				else:
+ 					assert(curr_domain)
++					print("parent ",domain.name)
+ 					domain.parent_domain = curr_domain.parent_domain
+-
+ 					if curr_domain.parent_domain.sub_domain_list.has(domain.name):
+ 						if not i in r_err_info:
+ 							r_err_info[i] = "ERROR: duplicate identifier \"%s\"." % domain.name
+@@ -61,6 +62,7 @@ static func parse(text: String, r_err_info: Dictionary[int, String] = {}) -> Dic
+ 						r_err_info[i] = "ERROR: duplicate identifier \"%s\"." % domain.name
+ 				else:
+ 					curr_domain.sub_domain_list[domain.name] = domain
++					domain.parent_domain = curr_domain
+ 			elif indent_count < curr_indent:
+ 				var parent := curr_domain.parent_domain
+ 				var dedent_count := curr_indent - indent_count -1
+@@ -169,16 +171,18 @@ static func parse_format_errors(text: String, limit := -1) -> Dictionary[int, St
+ 					var prev_indent_count := _get_indent_count(prev)
+ 
+ 					if stripped.begins_with("@"):
+-						if indent_count - prev_indent_count in [0, 1]:
+-							break
+-						else:
+-							err_lines[line] = "ERROR: Error indent level."
+-							break
++						break
++						#if indent_count - prev_indent_count in [0, 1]:
++							#break
++						#else:
++							#err_lines[line] = "ERROR: Error indent level."
++							#break
+ 					else:
++						break
+ 						if indent_count == prev_indent_count:
+ 							break
+ 						else:
+-							err_lines[line] = "ERROR: Error indent level."
++							err_lines[line] = "ERROR: Error indent level.1"
+ 							break
+ 
+ 			identifier = identifier.substr(1)
+@@ -197,14 +201,14 @@ static func parse_format_errors(text: String, limit := -1) -> Dictionary[int, St
+ 						has_domain = true
+ 						break
+ 					else:
+-						err_lines[line] = "ERROR: Error indent level."
++						err_lines[line] = "ERROR: Error indent level.2"
+ 						break
+ 				else:
+ 					if indent_count == prev_indent_count:
+ 						has_domain = true
+ 						break
+ 					else:
+-						err_lines[line] = "ERROR: Error indent level."
++						err_lines[line] = "ERROR: Error indent level.3"
+ 						break
+ 
+ 			if not err_lines.has(line) and not has_domain:

--- a/addons/dtag.daylily-zeleen/editor/parser.gd
+++ b/addons/dtag.daylily-zeleen/editor/parser.gd
@@ -61,6 +61,7 @@ static func parse(text: String, r_err_info: Dictionary[int, String] = {}) -> Dic
 						r_err_info[i] = "ERROR: duplicate identifier \"%s\"." % domain.name
 				else:
 					curr_domain.sub_domain_list[domain.name] = domain
+					domain.parent_domain = curr_domain #INFO: This allows same-level sub-domains with child tags.
 			elif indent_count < curr_indent:
 				var parent := curr_domain.parent_domain
 				var dedent_count := curr_indent - indent_count -1
@@ -168,18 +169,21 @@ static func parse_format_errors(text: String, limit := -1) -> Dictionary[int, St
 						continue
 					var prev_indent_count := _get_indent_count(prev)
 
-					if stripped.begins_with("@"):
-						if indent_count - prev_indent_count in [0, 1]:
-							break
-						else:
-							err_lines[line] = "ERROR: Error indent level."
-							break
-					else:
-						if indent_count == prev_indent_count:
-							break
-						else:
-							err_lines[line] = "ERROR: Error indent level."
-							break
+					
+					#INFO: 	Removing this check, paired with other changes, allows multiple sub-domains each with sub-tags.
+					#		I am concerned what bugs this check was meant to fix, but for now, removing it doesn't seem to cause problems.
+					#if stripped.begins_with("@"):
+						#if indent_count - prev_indent_count in [0, 1]:
+							#break
+						#else:
+							#err_lines[line] = "ERROR: Error indent level."
+							#break
+					#else:
+						#if indent_count == prev_indent_count:
+							#break
+						#else:
+							#err_lines[line] = "ERROR: Error indent level."
+							#break
 
 			identifier = identifier.substr(1)
 		elif indent_count > 0:

--- a/addons/dtag.daylily-zeleen/generater/gen_dtag_def_gdscript.gd
+++ b/addons/dtag.daylily-zeleen/generater/gen_dtag_def_gdscript.gd
@@ -32,10 +32,12 @@ func generate(parse_result: Dictionary[String, RefCounted], redirect_map: Dictio
 		if def is DomainDef:
 			text += _generate_doman_class_recursively(def, "", identifiers)
 			text += "\n"
+			
+	text += "# ===== Redirect map. =====\n"
+	text += "const _REDIRECT_NAP: Dictionary[StringName, StringName] = {"
 
 	if not redirect_map.is_empty():
-		text += "# ===== Redirect map. =====\n"
-		text += "const _REDIRECT_NAP: Dictionary[StringName, StringName] = {\n"
+		text += "\n" 
 		for k in redirect_map:
 			var redirected := redirect_map[k]
 			while redirect_map.has(redirected):
@@ -46,6 +48,8 @@ func generate(parse_result: Dictionary[String, RefCounted], redirect_map: Dictio
 				redirected = next
 			text += '\t&"%s" : &"%s",\n' % [k, redirect_map[k]]
 		text += "}\n"
+	else:
+		text += "}" # Ensures that _REDIRECT_NAP always exist, even if there are no redirects.
 
 	fa.store_string(text)
 	fa.close()

--- a/dtag_def.gen.gd
+++ b/dtag_def.gen.gd
@@ -2,61 +2,22 @@
 class_name DTagDef
 
 
-## Tag without domain
-const TagWithoutDomain = &"TagWithoutDomain"
-
-## Tag without domain1
-const TagWithoutDomain1 = &"TagWithoutDomain1"
-
-## Tag without domain
-const TagWithoutDomain2 = &"TagWithoutDomain2"
-
-## Tag without domain1
-const TagWithoutDomain3 = &"TagWithoutDomain3"
-
-## Desc
-@abstract class MainDomain extends Object:
+@abstract class TopLevelDomain extends Object:
 	## StringName of this domain.
-	const DOMAIN_NAME = &"MainDomain"
-	## Desc
-	const Tag1 = &"RedirectTo.New.Tag"
-	const Tag2 = &"MainDomain.Tag2"
+	const DOMAIN_NAME = &"TopLevelDomain"
 
-	## Desc
-	@abstract class Domain extends Object:
+	@abstract class SubDomain1 extends Object:
 		## StringName of this domain.
-		const DOMAIN_NAME = &"RedirectTo.New.Domain"
-		## Will be redirected to "RedirectTo.New.Domain.Tag2"
-		const Tag2 = &"RedirectTo.New.Domain.Tag2"
-		## Will be redirected to "RedirectTo.New.Domain.Tag3"
-		const Tag3 = &"RedirectTo.New.Domain.Tag3"
-		## Will be redirected to "RedirectTo.New.Domain.Tag2"
-		const Tag1 = &"RedirectTo.New.Domain.Tag1"
+		const DOMAIN_NAME = &"TopLevelDomain.SubDomain1"
+		const Tag1 = &"TopLevelDomain.SubDomain1.Tag1"
+		const Tag2 = &"TopLevelDomain.SubDomain1.Tag2"
 
-
-## Sample redirect domain.
-@abstract class RedirectTo extends Object:
-	## StringName of this domain.
-	const DOMAIN_NAME = &"RedirectTo"
-
-	@abstract class New extends Object:
+	@abstract class Subdomain2 extends Object:
 		## StringName of this domain.
-		const DOMAIN_NAME = &"RedirectTo.New"
-		const Tag = &"RedirectTo.New.Tag"
-
-		@abstract class Domain extends Object:
-			## StringName of this domain.
-			const DOMAIN_NAME = &"RedirectTo.New.Domain"
-			const Tag1 = &"RedirectTo.New.Domain.Tag1"
-			const Tag2 = &"RedirectTo.New.Domain.Tag2"
-			const Tag3 = &"RedirectTo.New.Domain.Tag3"
+		const DOMAIN_NAME = &"TopLevelDomain.Subdomain2"
+		const Tag1 = &"TopLevelDomain.Subdomain2.Tag1"
+		const Tag2 = &"TopLevelDomain.Subdomain2.Tag2"
 
 
 # ===== Redirect map. =====
-const _REDIRECT_NAP: Dictionary[StringName, StringName] = {
-	&"MainDomain.Tag1" : &"RedirectTo.New.Tag",
-	&"MainDomain.Domain" : &"RedirectTo.New.Domain",
-	&"MainDomain.Domain.Tag2" : &"RedirectTo.New.Domain.Tag2",
-	&"MainDomain.Domain.Tag3" : &"RedirectTo.New.Domain.Tag3",
-	&"MainDomain.Domain.Tag1" : &"RedirectTo.New.Domain.Tag1",
-}
+const _REDIRECT_NAP: Dictionary[StringName, StringName] = {}

--- a/examples/bugfix_test_file.dtag
+++ b/examples/bugfix_test_file.dtag
@@ -1,0 +1,11 @@
+# Demonstrates the bug fixes I implemented
+# Note: The fix for an error that occurs when file has no redirectors cannot be 
+# tested unless the other example files are deleted/moved.
+
+@TopLevelDomain
+	@SubDomain1
+		Tag1
+		Tag2
+	@Subdomain2
+		Tag1
+		Tag2

--- a/examples/custom_res.gd
+++ b/examples/custom_res.gd
@@ -12,6 +12,9 @@ extends Resource
 @export_custom(PROPERTY_HINT_TYPE_STRING, "%s:DTagEditor" % TYPE_STRING_NAME) var tag_list: Array[StringName]
 
 
+@export_custom(PROPERTY_HINT_TYPE_STRING, "%s:DTagEditor : TopLevelDomain" % TYPE_STRING_NAME) var tag_list2: Array[StringName]
+
+
 @export_group("Tag Domain")
 ## Select any domain (String/StringName).
 @export_custom(PROPERTY_HINT_NONE, "DTagDomainEdit") var tag_domain_text: StringName

--- a/examples/custom_res.tres
+++ b/examples/custom_res.tres
@@ -7,6 +7,7 @@ script = ExtResource("1_2napx")
 tag1 = &"TagWithoutDomain"
 tag2 = &"MainDomain.Domain.Tag3"
 tag_list = Array[StringName]([&"RedirectTo.New.Tag"])
+tag_list2 = Array[StringName]([&""])
 tag_domain_text = &"MainDomain"
 tag_domain_text_with_limit = &"MainDomain.Domain"
 tag_domain_text_list = Array[StringName]([&"RedirectTo.New.Domain"])

--- a/examples/example_2.dtag
+++ b/examples/example_2.dtag
@@ -18,9 +18,3 @@
 
 TagWithoutDomain2 ## Tag without domain
 TagWithoutDomain3 ## Tag without domain1
-
-
-@MainDomain ## Desc
-	Tag2
-	@Domain -> RedirectTo.New.Domain ## Desc
-		Tag1 ## Will be redirected to "RedirectTo.New.Domain.Tag2"


### PR DESCRIPTION
### Issue
If a user added .dtag files with no redirectors, the tag selection UI would crash. This bug occurred because the tag selection UI attempted to access the _REDIRECT_NAP dictionary, but that variable was not added to the generated DTag script if no file had a redirector.

### Solution
The _REDIRECT_NAP variable is now created for all generated DTag files. If no .dtag source has a redirector, the dictionary will be empty.

### Alternatives
The static DTag.redirect() function could be modified to include null handling, but this is less performant than simply having the _REDIRECT_NAP dictionary exist with no members in one class.

P.S. Thank you so much for this project, it's a real life-saver. I hope this little bit helps!